### PR TITLE
feat: Dev Container環境と開発ドキュメントを追加

### DIFF
--- a/.cursor/rules/global.md
+++ b/.cursor/rules/global.md
@@ -1,0 +1,190 @@
+# Cursor Rules for sysdig-vuls-utils
+
+このプロジェクトはSysdig脆弱性管理APIツールセットです。以下のガイドラインに従って開発を行ってください。
+
+## 言語設定
+- ドキュメントは日本語で記述する
+- コード内のコメントは日本語で記述する
+- gitコミットメッセージは日本語で記述する
+
+## プロジェクト概要
+SysdigのクラウドベースRCE（ランタイムコンテナセキュリティ）が検出した脆弱性を管理するためのGolang製CLIツール＆ライブラリ。
+
+## DevContainer環境での開発
+
+### 作業ディレクトリ
+- コンテナ内の作業ディレクトリ: `/workspace`
+- プロジェクトのソースコードは `/workspace` 直下に配置される
+- すべてのコマンドは `/workspace` から実行される
+
+### DevContainer内でのGoコマンド実行
+```bash
+# ビルド（/workspaceから実行）
+cd /workspace
+go build -o bin/sysdig-vuls cmd/sysdig-vuls/main.go
+
+# テスト実行
+cd /workspace
+go test ./...
+go test -v ./pkg/...
+
+# 特定パッケージのテスト
+go test -v ./pkg/sysdig
+go test -v ./pkg/config
+
+# カバレッジ付きテスト
+go test -v -coverprofile=coverage.out ./...
+go tool cover -html=coverage.out -o coverage.html
+
+# ベンチマークテスト
+go test -bench=. ./...
+
+# 依存関係の管理
+go mod tidy
+go mod download
+go mod verify
+
+# コードフォーマット
+go fmt ./...
+gofmt -s -w .
+
+# 静的解析
+golangci-lint run
+staticcheck ./...
+```
+
+### DevContainerでの開発フロー
+1. VS Codeで「Reopen in Container」を実行
+2. コンテナが起動すると自動的に `/workspace` に移動
+3. `go mod download` と `make deps` が自動実行される
+4. ターミナルから直接Goコマンドやmakeコマンドを実行可能
+
+## アーキテクチャとコード規約
+
+### パッケージ構造
+- `cmd/sysdig-vuls/`: CLIアプリケーションのエントリポイント
+- `pkg/sysdig/`: Sysdig APIクライアント実装
+- `pkg/config/`: 設定管理ロジック
+
+### コード実装時の注意
+1. **API呼び出し**: すべてのAPI呼び出しは`pkg/sysdig/client.go`の`makeRequest()`メソッドを通じて実行する
+2. **エラーハンドリング**: 404エラーは特別に処理し、その他はHTTPステータス付きでエラーを返す
+3. **設定優先順位**: CLIフラグ > 設定ファイル > 環境変数 > デフォルト値の順で適用
+4. **タイムアウト**: HTTPクライアントのタイムアウトは30秒に設定
+
+## 開発コマンド
+
+### よく使うコマンド
+```bash
+# ビルド
+make build           # 単一プラットフォーム用
+make build-all      # 全プラットフォーム用
+
+# テスト
+make test           # 全テスト実行
+make test-coverage  # カバレッジ付きテスト
+
+# 品質チェック
+make lint           # golangci-lintでリント
+make fmt            # コードフォーマット
+
+# 実行
+make run            # ビルドして実行
+./bin/sysdig-vuls -token YOUR_TOKEN -command list
+```
+
+## API統合
+
+### Sysdig API エンドポイント
+- ベースURL: `https://us2.app.sysdig.com/api/secure/v1`
+- 認証: Bearer トークン（ヘッダー: `Authorization: Bearer <token>`）
+
+### 主要エンドポイント
+- `GET /vulnerabilities` - 全脆弱性一覧
+- `GET /vulnerabilities/{id}` - 特定脆弱性詳細
+- `PATCH /vulnerabilities/{id}` - 脆弱性更新
+- `GET /vulnerabilities?severity={level}` - 重要度フィルタ
+- `GET /vulnerabilities?package={name}` - パッケージフィルタ
+
+## データ構造
+
+### Vulnerability構造体
+```go
+type Vulnerability struct {
+    ID          string   // 脆弱性ID
+    CVE         string   // CVE番号
+    Severity    string   // 重要度 (critical/high/medium/low)
+    Status      string   // ステータス
+    Description string   // 説明
+    Packages    []string // 影響パッケージ
+    Score       float64  // CVSSスコア
+    Vector      string   // CVSSベクトル
+    PublishedAt string   // 公開日時
+    UpdatedAt   string   // 更新日時
+    Metadata    map[string]interface{} // メタデータ
+}
+```
+
+## 環境変数
+- `SYSDIG_API_TOKEN`: APIトークン（必須）
+- `SYSDIG_API_URL`: APIベースURL（デフォルト: https://us2.app.sysdig.com）
+
+## リージョン別エンドポイント
+- 米国東部（デフォルト）: `https://us2.app.sysdig.com`
+- 米国西部: `https://us3.app.sysdig.com`
+- EU: `https://eu1.app.sysdig.com`
+- アジア太平洋: `https://au1.app.sysdig.com`
+
+## コード変更時のガイドライン
+
+1. **新機能追加時**
+   - `pkg/sysdig/client.go`にAPIメソッドを追加
+   - `cmd/sysdig-vuls/main.go`にCLIコマンドを追加
+   - 適切なエラーハンドリングを実装
+
+2. **テスト追加**
+   - 新しい機能には必ずユニットテストを追加
+   - `make test`で全テストが通ることを確認
+
+3. **ドキュメント更新**
+   - README.mdの使用例を更新
+   - CLAUDE.mdのアーキテクチャ情報を更新
+
+## デバッグのヒント
+
+### DevContainer内でのデバッグ
+```bash
+# delveデバッガを使用したデバッグ
+cd /workspace
+dlv debug cmd/sysdig-vuls/main.go -- -token YOUR_TOKEN -command list
+
+# テスト時のデバッグ
+dlv test ./pkg/sysdig
+
+# ブレークポイントの設定例
+(dlv) break main.main
+(dlv) break pkg/sysdig.(*Client).ListVulnerabilities
+(dlv) continue
+(dlv) print vulnResp
+```
+
+### VSCode統合デバッグ
+DevContainer環境では、VSCodeのデバッグ機能が自動設定されています：
+1. 左サイドバーの「Run and Debug」を開く
+2. 「create a launch.json file」をクリック
+3. 「Go」を選択
+4. F5でデバッグ開始
+
+### ログ出力の追加
+- API呼び出しの詳細を確認したい場合は、`pkg/sysdig/client.go`の`makeRequest()`にログを追加
+- レスポンスボディを確認する場合は、エラー処理部分でbodyを出力
+```go
+// デバッグ用ログの例
+log.Printf("API Request: %s %s", method, url)
+log.Printf("Response Status: %d", resp.StatusCode)
+```
+
+## セキュリティ注意事項
+- APIトークンをコードにハードコードしない
+- 設定ファイルのパーミッションは600に設定（`config.Save()`で自動設定）
+- APIトークンは環境変数か設定ファイルで管理

--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -1,0 +1,11 @@
+# Sysdig API設定
+SYSDIG_API_TOKEN=your_sysdig_api_token_here
+SYSDIG_API_URL=https://us2.app.sysdig.com
+
+# GitHub設定（PR作成時に使用）
+GITHUB_TOKEN=your_github_personal_access_token
+
+# プロキシ設定（必要な場合）
+# HTTP_PROXY=http://proxy.example.com:8080
+# HTTPS_PROXY=http://proxy.example.com:8080
+# NO_PROXY=localhost,127.0.0.1

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,39 @@
+# Go開発環境用Dockerfile
+# Microsoft Dev Containers Goイメージを使用
+FROM mcr.microsoft.com/devcontainers/go:1-1.23-bookworm
+
+# 作業ディレクトリ設定
+WORKDIR /workspace
+
+# 追加の開発ツールをインストール（基本ツールは既にベースイメージに含まれている）
+RUN apt-get update && apt-get install -y \
+    jq \
+    vim \
+    bash-completion \
+    && rm -rf /var/lib/apt/lists/*
+
+# golangci-lintのインストール（最新版）
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.57.2
+
+# 追加のGo開発用ツールのインストール（基本的なツールは既にインストール済み）
+RUN go install github.com/cweill/gotests/gotests@latest \
+    && go install honnef.co/go/tools/cmd/staticcheck@latest
+
+# GitHub CLIは既にベースイメージに含まれているため、追加インストール不要
+
+# vsodeユーザー用エイリアス設定（Microsoft Dev Containersイメージにはvsocdeユーザーが存在）
+USER vscode
+RUN echo "alias ll='ls -la'" >> ~/.bashrc \
+    && echo "alias gs='git status'" >> ~/.bashrc \
+    && echo "alias gd='git diff'" >> ~/.bashrc
+
+# Go環境変数設定
+ENV GO111MODULE=on \
+    GOPROXY=https://proxy.golang.org,direct \
+    CGO_ENABLED=0
+
+# ワークスペースのGoモジュールキャッシュ用ボリュームマウントポイント
+VOLUME ["/go/pkg/mod"]
+
+# デフォルトユーザーに戻す
+USER root

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,110 @@
+{
+  "name": "Sysdig Vuls Utils Dev Container",
+  "dockerFile": "Dockerfile",
+
+  // コンテナ作成時の設定
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "..",
+    "args": {}
+  },
+
+  // コンテナ実行時の設定
+  "runArgs": [
+    "--cap-add=SYS_PTRACE",
+    "--security-opt", "seccomp=unconfined"
+  ],
+
+  // マウント設定
+  "mounts": [
+    "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+    "source=go-modules,target=/go/pkg/mod,type=volume"
+  ],
+
+  // 環境変数
+  "remoteEnv": {
+    "GOPATH": "/go",
+    "GOBIN": "/go/bin",
+    "PATH": "${containerEnv:PATH}:/go/bin",
+    "GO111MODULE": "on",
+    "GOPROXY": "https://proxy.golang.org,direct"
+  },
+
+  // VS Code拡張機能
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "ms-azuretools.vscode-docker",
+        "eamodio.gitlens",
+        "donjayamanne.githistory",
+        "streetsidesoftware.code-spell-checker",
+        "yzhang.markdown-all-in-one",
+        "redhat.vscode-yaml",
+        "ms-vscode.makefile-tools",
+        "GitHub.copilot",
+        "GitHub.copilot-chat",
+        "wayou.vscode-todo-highlight",
+        "gruntfuggly.todo-tree"
+      ],
+      "settings": {
+        "go.toolsManagement.checkForUpdates": "local",
+        "go.useLanguageServer": true,
+        "go.lintTool": "golangci-lint",
+        "go.lintOnSave": "workspace",
+        "go.formatTool": "goimports",
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+          "source.organizeImports": "explicit"
+        },
+        "[go]": {
+          "editor.formatOnSave": true,
+          "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit"
+          },
+          "editor.snippetSuggestions": "none"
+        },
+        "[go.mod]": {
+          "editor.formatOnSave": true,
+          "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit"
+          }
+        },
+        "gopls": {
+          "usePlaceholders": true,
+          "staticcheck": true
+        },
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "/bin/bash"
+          }
+        },
+        "files.exclude": {
+          "**/bin": true,
+          "**/.git": true,
+          "**/vendor": false
+        },
+        "files.watcherExclude": {
+          "**/bin": true,
+          "**/vendor": true
+        }
+      }
+    }
+  },
+
+  // コンテナ作成後に実行するコマンド
+  "postCreateCommand": "go mod download && make deps",
+
+  // 開始時のコマンド
+  "postStartCommand": "git config --global --add safe.directory /workspace",
+
+  // リモートユーザー
+  "remoteUser": "vscode",
+
+  // ワークスペースフォルダ
+  "workspaceFolder": "/workspace",
+
+  // フォワードするポート
+  "forwardPorts": []
+}

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ go.work.sum
 
 # env file
 .env
+.env.local
+.devcontainer/.env
 
 # Build directory
 bin/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,51 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch CLI",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/cmd/sysdig-vuls/main.go",
+      "env": {
+        "SYSDIG_API_TOKEN": "${env:SYSDIG_API_TOKEN}",
+        "SYSDIG_API_URL": "${env:SYSDIG_API_URL}"
+      },
+      "args": ["-command", "list"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "Debug Test Package",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${workspaceFolder}/pkg/...",
+      "env": {
+        "SYSDIG_API_TOKEN": "${env:SYSDIG_API_TOKEN}",
+        "SYSDIG_API_URL": "${env:SYSDIG_API_URL}"
+      },
+      "args": ["-test.v"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "Debug Current Test",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${fileDirname}",
+      "env": {
+        "SYSDIG_API_TOKEN": "${env:SYSDIG_API_TOKEN}",
+        "SYSDIG_API_URL": "${env:SYSDIG_API_URL}"
+      },
+      "args": ["-test.v", "-test.run", "${selectedText}"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "Attach to Process",
+      "type": "go",
+      "request": "attach",
+      "mode": "local",
+      "processId": "${command:pickProcess}"
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,163 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## 開発環境
+
+### Dev Container環境
+このプロジェクトは`.devcontainer`設定を含んでおり、VS CodeまたはGitHub Codespacesで統一された開発環境を提供します。
+
+#### Dev Container構成
+- **ベースイメージ**: mcr.microsoft.com/devcontainers/go:1-1.23-bookworm
+- **開発ツール**: golangci-lint、delve、gopls、staticcheck等がプリインストール
+- **VS Code拡張**: Go、Docker、GitLens、GitHub Copilot等が自動設定
+- **GitHub CLI**: PR作成・管理用にgh CLIを統合
+- **Docker-in-Docker**: コンテナ内でDockerコマンド実行可能
+
+#### 環境変数設定
+`.devcontainer/.env.example`をコピーして`.devcontainer/.env`を作成し、必要な環境変数を設定：
+```bash
+cp .devcontainer/.env.example .devcontainer/.env
+# SYSDIG_API_TOKENとSYSDIG_API_URLを設定
+```
+
+#### 作業ディレクトリ
+- コンテナ内の作業ディレクトリは `/workspace`
+- すべてのコマンドは `/workspace` から実行
+- ソースコードは `/workspace` 直下に自動マウント
+
+## 開発コマンド
+
+### ビルド
+```bash
+# 単一プラットフォーム用バイナリをビルド
+make build
+
+# 複数プラットフォーム用バイナリをビルド（Linux, macOS Intel/ARM, Windows）
+make build-all
+
+# ビルド成果物をクリーン
+make clean
+```
+
+### テスト
+```bash
+# 全テストを実行
+make test
+# または直接Goコマンドで
+go test ./...
+
+# カバレッジ付きでテストを実行
+make test-coverage
+# または直接Goコマンドで
+go test -v -coverprofile=coverage.out ./...
+go tool cover -html=coverage.out -o coverage.html
+
+# 特定パッケージのテスト
+go test -v ./pkg/sysdig
+go test -v ./pkg/config
+
+# ベンチマークテスト
+go test -bench=. ./...
+```
+
+### 開発ツール
+```bash
+# コードのリント（要golangci-lint）
+make lint
+# または直接実行
+golangci-lint run
+
+# 静的解析
+staticcheck ./...
+
+# コードフォーマット
+make fmt
+# または直接実行
+go fmt ./...
+gofmt -s -w .
+
+# 依存関係の管理
+make deps
+# または直接実行
+go mod tidy
+go mod download
+go mod verify
+```
+
+### デバッグ
+```bash
+# delveデバッガでデバッグ実行
+dlv debug cmd/sysdig-vuls/main.go -- -token YOUR_TOKEN -command list
+
+# テストのデバッグ
+dlv test ./pkg/sysdig
+
+# VS Codeデバッグ（.vscode/launch.json設定済み）
+# F5キーでデバッグ開始
+```
+
+### アプリケーション実行
+```bash
+# ビルドして実行
+make run
+
+# または直接実行（APIトークンが必要）
+./bin/sysdig-vuls -token YOUR_TOKEN -command list
+```
+
+## アーキテクチャ概要
+
+このツールはSysdig Secure APIと連携してコンテナ環境の脆弱性を管理するCLIツール兼Goライブラリです。
+
+### パッケージ構造
+
+1. **cmd/sysdig-vuls/main.go**
+   - CLIエントリポイント
+   - コマンド解析とルーティング（list、get、update）
+   - 設定優先順位：CLIフラグ > 設定ファイル > 環境変数 > デフォルト値
+
+2. **pkg/sysdig/client.go**
+   - Sysdig APIクライアント実装
+   - HTTPクライアント（30秒タイムアウト）
+   - Bearer認証使用
+   - エンドポイント：`/api/secure/v1/vulnerabilities`
+   - メソッド：
+     - `ListVulnerabilities()`: 全脆弱性取得
+     - `GetVulnerability(id)`: 特定脆弱性取得
+     - `UpdateVulnerability(id, updates)`: 脆弱性更新
+     - `ListVulnerabilitiesByPackage(name)`: パッケージ別フィルタ
+     - `ListVulnerabilitiesBySeverity(level)`: 重要度別フィルタ
+
+3. **pkg/config/config.go**
+   - 設定管理（JSON形式）
+   - 環境変数サポート：`SYSDIG_API_TOKEN`、`SYSDIG_API_URL`
+   - デフォルトURL：`https://us2.app.sysdig.com`
+
+### API統合パターン
+
+- すべてのAPI呼び出しは`makeRequest()`メソッドを通じて実行
+- レスポンスは`VulnerabilityResponse`構造体にデコード
+- エラーハンドリング：404は特別処理、その他はHTTPステータス付きエラー
+
+### 主要データ構造
+
+`Vulnerability`構造体には以下のフィールドが含まれる：
+- ID、CVE番号、重要度、ステータス
+- 説明、影響を受けるパッケージリスト
+- CVSSスコア、ベクトル
+- 公開日時、更新日時
+- メタデータ（汎用マップ）
+
+## APIドキュメント
+
+このツールはSysdig Secure APIをベースにしています。詳細なAPIドキュメントは以下を参照してください：
+
+- **Sysdig APIドキュメント**: https://us2.app.sysdig.com/apidocs/secure?_product=SDS
+- **Swagger UI**: https://us2.app.sysdig.com/secure/swagger.html
+
+## 注意事項
+
+- Go 1.23を使用（go.modで指定）
+- APIトークンは必須（取得先：Sysdig UIの設定画面）
+- 現在サポートしているリージョン：US2（デフォルト）、US3、EU1、AU1

--- a/README.md
+++ b/README.md
@@ -1,27 +1,51 @@
 # sysdig-vuls-utils
 
-**Sysdig Vulnerability API Tool-set**
+**Sysdig脆弱性管理APIツールセット**
 
-A Golang-based command-line tool and library for interacting with Sysdig's vulnerability management API. This tool allows you to list, retrieve, and manage vulnerabilities in your Sysdig Cloud environment.
+SysdigのクラウドベースRCE（ランタイムコンテナセキュリティ）が検出した脆弱性を管理するためのGolang製コマンドラインツール＆ライブラリです。Sysdig Cloud環境における脆弱性の一覧取得、詳細情報の取得、ステータス更新などが可能です。
 
-## Features
+## 機能
 
-- **List Vulnerabilities**: Retrieve all vulnerabilities from your Sysdig environment
-- **Get Vulnerability Details**: Fetch detailed information about specific vulnerabilities
-- **Update Vulnerabilities**: Modify vulnerability status and metadata
-- **Filter by Severity**: Query vulnerabilities by severity level (critical, high, medium, low)
-- **Filter by Package**: Find vulnerabilities affecting specific packages
-- **Configuration Management**: Support for config files, environment variables, and CLI flags
-- **JSON Output**: Machine-readable output for integration with other tools
+- **脆弱性一覧の取得**: Sysdig環境内のすべての脆弱性を取得
+- **脆弱性詳細の取得**: 特定の脆弱性の詳細情報を取得
+- **脆弱性の更新**: 脆弱性のステータスやメタデータを変更
+- **重要度でフィルタリング**: 重要度レベル（critical、high、medium、low）で脆弱性を検索
+- **パッケージでフィルタリング**: 特定のパッケージに影響する脆弱性を検索
+- **設定管理**: 設定ファイル、環境変数、CLIフラグをサポート
+- **JSON出力**: 他のツールとの統合に適した機械可読な出力形式
 
-## Installation
+## インストール
 
-### Prerequisites
+### 前提条件
 
-- Go 1.19 or later
-- Valid Sysdig API token
+- Go 1.23以降
+- 有効なSysdig APIトークン
 
-### Build from Source
+### Dev Container (VS Code/GitHub Codespaces)
+
+このプロジェクトはDev Containerをサポートしています。VS CodeやGitHub Codespacesで簡単に開発環境を構築できます。
+
+#### VS Codeで使用する場合
+
+1. Docker DesktopとVS Code Dev Containers拡張をインストール
+2. プロジェクトをVS Codeで開く
+3. コマンドパレット（F1）から「Dev Containers: Reopen in Container」を選択
+4. 自動的に開発環境が構築されます
+
+#### GitHub Codespacesで使用する場合
+
+1. GitHubリポジトリページで「Code」→「Codespaces」→「Create codespace on main」をクリック
+2. 自動的にクラウド上に開発環境が構築されます
+
+#### Dev Container環境の特徴
+
+- Go 1.23開発環境（Microsoft Dev Containersベース）
+- golangci-lint、dlv、goplsなどの開発ツール事前インストール済み
+- VS Code Go拡張機能自動セットアップ
+- GitHub CLI統合
+- Dockerサポート（Docker-in-Docker）
+
+### ソースからビルド
 
 ```bash
 git clone https://github.com/kaz-under-the-bridge/sysdig-vuls-utils.git
@@ -29,39 +53,39 @@ cd sysdig-vuls-utils
 go build -o sysdig-vuls cmd/sysdig-vuls/main.go
 ```
 
-### Install with Go
+### Goでインストール
 
 ```bash
 go install github.com/kaz-under-the-bridge/sysdig-vuls-utils/cmd/sysdig-vuls@latest
 ```
 
-## Configuration
+## 設定
 
-### API Token
+### APIトークン
 
-You need a valid Sysdig API token to use this tool. You can obtain one from:
+このツールを使用するには有効なSysdig APIトークンが必要です。以下から取得できます：
 - **Sysdig US2**: https://us2.app.sysdig.com/secure/settings/user
 - **Sysdig EU**: https://eu1.app.sysdig.com/secure/settings/user
 
-### Configuration Options
+### 設定オプション
 
-The tool supports multiple ways to configure the API token and endpoint:
+ツールは以下の複数の方法でAPIトークンとエンドポイントを設定できます：
 
-1. **Command Line Flags** (highest priority)
-2. **Configuration File** (JSON format)
-3. **Environment Variables**
-4. **Default Values** (lowest priority)
+1. **コマンドラインフラグ** （最優先）
+2. **設定ファイル** （JSON形式）
+3. **環境変数**
+4. **デフォルト値** （最低優先度）
 
-#### Environment Variables
+#### 環境変数
 
 ```bash
 export SYSDIG_API_TOKEN="your_api_token_here"
 export SYSDIG_API_URL="https://us2.app.sysdig.com"  # Optional, defaults to US2
 ```
 
-#### Configuration File
+#### 設定ファイル
 
-Create a JSON configuration file (see `examples/config.json`):
+JSON形式の設定ファイルを作成します（`examples/config.json`を参照）：
 
 ```json
 {
@@ -70,72 +94,72 @@ Create a JSON configuration file (see `examples/config.json`):
 }
 ```
 
-## Usage
+## 使用方法
 
-### Command Line Interface
+### コマンドラインインターフェース
 
 ```bash
 sysdig-vuls [options]
 ```
 
-#### Options
+#### オプション
 
-- `-config string`: Path to configuration file
-- `-token string`: Sysdig API token (or use SYSDIG_API_TOKEN environment variable)
-- `-url string`: Sysdig API base URL (default: "https://us2.app.sysdig.com")
-- `-command string`: Command to execute: list, get, update (default: "list")
-- `-id string`: Vulnerability ID (required for get/update commands)
-- `-help`: Show help message
-- `-version`: Show version information
+- `-config string`: 設定ファイルへのパス
+- `-token string`: Sysdig APIトークン（またはSYSDIG_API_TOKEN環境変数を使用）
+- `-url string`: Sysdig APIベースURL（デフォルト: "https://us2.app.sysdig.com"）
+- `-command string`: 実行するコマンド: list, get, update（デフォルト: "list"）
+- `-id string`: 脆弱性ID（get/updateコマンドで必須）
+- `-help`: ヘルプメッセージを表示
+- `-version`: バージョン情報を表示
 
-### Examples
+### 使用例
 
-#### List All Vulnerabilities
+#### すべての脆弱性を一覧表示
 
 ```bash
-# Using environment variable
+# 環境変数を使用
 export SYSDIG_API_TOKEN="your_token_here"
 sysdig-vuls -command list
 
-# Using command line flag
+# コマンドラインフラグを使用
 sysdig-vuls -token "your_token_here" -command list
 
-# Using config file
+# 設定ファイルを使用
 sysdig-vuls -config config.json -command list
 ```
 
-#### Get Specific Vulnerability
+#### 特定の脆弱性を取得
 
 ```bash
 sysdig-vuls -token "your_token_here" -command get -id CVE-2023-1234
 ```
 
-#### Update Vulnerability Status
+#### 脆弱性ステータスの更新
 
 ```bash
 sysdig-vuls -token "your_token_here" -command update -id CVE-2023-1234
 ```
 
-## API Documentation
+## APIドキュメント
 
-This tool is based on the Sysdig Secure API. For detailed API documentation, refer to:
+このツールはSysdig Secure APIをベースにしています。詳細なAPIドキュメントは以下を参照してください：
 
-- **Sysdig API Documentation**: https://us2.app.sysdig.com/apidocs/secure?_product=SDS
+- **Sysdig APIドキュメント**: https://us2.app.sysdig.com/apidocs/secure?_product=SDS
 - **Swagger UI**: https://us2.app.sysdig.com/secure/swagger.html
 
-### Supported API Endpoints
+### サポートされているAPIエンドポイント
 
-The tool currently supports the following Sysdig API endpoints:
+ツールは現在、以下のSysdig APIエンドポイントをサポートしています：
 
-#### Vulnerabilities
+#### 脆弱性
 
-- `GET /api/secure/v1/vulnerabilities` - List all vulnerabilities
-- `GET /api/secure/v1/vulnerabilities/{id}` - Get specific vulnerability
-- `PATCH /api/secure/v1/vulnerabilities/{id}` - Update vulnerability
-- `GET /api/secure/v1/vulnerabilities?severity={level}` - Filter by severity
-- `GET /api/secure/v1/vulnerabilities?package={name}` - Filter by package
+- `GET /api/secure/v1/vulnerabilities` - すべての脆弱性を一覧表示
+- `GET /api/secure/v1/vulnerabilities/{id}` - 特定の脆弱性を取得
+- `PATCH /api/secure/v1/vulnerabilities/{id}` - 脆弱性を更新
+- `GET /api/secure/v1/vulnerabilities?severity={level}` - 重要度でフィルタリング
+- `GET /api/secure/v1/vulnerabilities?package={name}` - パッケージでフィルタリング
 
-### API Response Format
+### APIレスポンス形式
 
 ```json
 {
@@ -160,9 +184,9 @@ The tool currently supports the following Sysdig API endpoints:
 }
 ```
 
-## Library Usage
+## ライブラリとしての使用
 
-You can also use this tool as a Go library in your own projects:
+独自のプロジェクトでGoライブラリとして使用することもできます：
 
 ```go
 package main
@@ -195,7 +219,7 @@ func main() {
 }
 ```
 
-### Available Client Methods
+### 利用可能なクライアントメソッド
 
 - `ListVulnerabilities() ([]Vulnerability, error)`
 - `GetVulnerability(vulnID string) (*Vulnerability, error)`
@@ -203,48 +227,48 @@ func main() {
 - `ListVulnerabilitiesByPackage(packageName string) ([]Vulnerability, error)`
 - `ListVulnerabilitiesBySeverity(severity string) ([]Vulnerability, error)`
 
-## Error Handling
+## エラー処理
 
-The tool provides comprehensive error handling:
+ツールは包括的なエラー処理を提供します：
 
-- **Authentication Errors**: Invalid or missing API tokens
-- **Network Errors**: Connection issues or timeouts
-- **API Errors**: Invalid requests or server errors
-- **Not Found Errors**: When requesting non-existent vulnerabilities
+- **認証エラー**: 無効または不足しているAPIトークン
+- **ネットワークエラー**: 接続の問題やタイムアウト
+- **APIエラー**: 無効なリクエストやサーバーエラー
+- **Not Foundエラー**: 存在しない脆弱性をリクエストした場合
 
-## Regional Endpoints
+## リージョン別エンドポイント
 
-Sysdig operates in multiple regions. Use the appropriate endpoint for your region:
+Sysdigは複数のリージョンで運用されています。お使いのリージョンに適したエンドポイントを使用してください：
 
-- **US East (default)**: `https://us2.app.sysdig.com`
-- **US West**: `https://us3.app.sysdig.com`
+- **米国東部（デフォルト）**: `https://us2.app.sysdig.com`
+- **米国西部**: `https://us3.app.sysdig.com`
 - **EU**: `https://eu1.app.sysdig.com`
-- **Asia Pacific**: `https://au1.app.sysdig.com`
+- **アジア太平洋**: `https://au1.app.sysdig.com`
 
-## Contributing
+## コントリビューション
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+1. リポジトリをフォーク
+2. フィーチャーブランチを作成（`git checkout -b feature/amazing-feature`）
+3. 変更をコミット（`git commit -m 'Add some amazing feature'`）
+4. ブランチにプッシュ（`git push origin feature/amazing-feature`）
+5. プルリクエストを作成
 
-## License
+## ライセンス
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+このプロジェクトはMITライセンスのもとでライセンスされています - 詳細は[LICENSE](LICENSE)ファイルを参照してください。
 
-## Support
+## サポート
 
-For issues and questions:
+問題や質問がある場合：
 
-1. Check the [GitHub Issues](https://github.com/kaz-under-the-bridge/sysdig-vuls-utils/issues)
-2. Refer to the [Sysdig Documentation](https://docs.sysdig.com/)
-3. Contact Sysdig Support for API-specific issues
+1. [GitHub Issues](https://github.com/kaz-under-the-bridge/sysdig-vuls-utils/issues)を確認
+2. [Sysdigドキュメント](https://docs.sysdig.com/)を参照
+3. API固有の問題についてはSysdigサポートに連絡
 
-## Changelog
+## 変更履歴
 
 ### v1.0.0
-- Initial release
-- Basic vulnerability listing, retrieval, and update functionality
-- Support for configuration files and environment variables
-- CLI tool and Go library
+- 初回リリース
+- 基本的な脆弱性の一覧表示、取得、更新機能
+- 設定ファイルと環境変数のサポート
+- CLIツールとGoライブラリ

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/kaz-under-the-bridge/sysdig-vuls-utils
 
-go 1.24.7
+go 1.23


### PR DESCRIPTION
## 概要
このPRは開発環境の改善と日本語ドキュメントの整備を行います。

## 変更内容

### 🐳 Dev Container環境の追加
- VS Code/GitHub Codespacesで即座に開発環境を構築可能に
- Go 1.23、golangci-lint、delve等の開発ツールをプリインストール
- Microsoft公式のDev Containersイメージを使用

### 📚 ドキュメント整備
- README.mdを日本語に翻訳し、国内開発者向けに最適化
- CLAUDE.mdで技術的な詳細と開発ガイドラインを文書化
- Cursor IDE用のルール設定を追加

### 🛠️ 開発環境の改善
- VS Codeデバッグ設定（.vscode/launch.json）を追加
- Goバージョンを最新安定版の1.23に統一
- .gitignoreを更新してDev Container関連ファイルを除外

## テスト手順
1. VS Codeで「Reopen in Container」を実行
2. コンテナ内で `make test` を実行して動作確認
3. F5キーでデバッグが動作することを確認

## 影響範囲
- 既存のコード変更なし
- 開発環境の設定のみ追加