### PR TITLE
docs: グローバルカスタムコマンドの説明を追加

### DIFF
--- a/.cursor/rules/global.md
+++ b/.cursor/rules/global.md
@@ -188,3 +188,20 @@ log.Printf("Response Status: %d", resp.StatusCode)
 - APIトークンをコードにハードコードしない
 - 設定ファイルのパーミッションは600に設定（`config.Save()`で自動設定）
 - APIトークンは環境変数か設定ファイルで管理
+
+## グローバルカスタムコマンド
+
+### Git操作コマンド（~/.claude/commands）
+```bash
+# mainブランチと同期（最新をプル）
+/git:sync
+
+# PR作成ワークフロー（コミット→ブランチ作成→プッシュ→PR作成）
+/git:pr "PRのタイトル"
+
+# 他のGitコマンドも利用可能
+/git:push-head  # 現在のHEADをリモートにプッシュ
+/git:rebase     # コミット履歴をリベース
+```
+
+これらのコマンドは`~/.claude/commands/`にグローバル定義されており、すべてのプロジェクトで利用可能。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,24 @@ make run
 - **Sysdig APIドキュメント**: https://us2.app.sysdig.com/apidocs/secure?_product=SDS
 - **Swagger UI**: https://us2.app.sysdig.com/secure/swagger.html
 
+## グローバルカスタムコマンド
+
+以下のGit操作コマンドがグローバルに定義されています（~/.claude/commands）：
+
+### /git:sync
+mainブランチに切り替えて最新の変更をプルします。
+```bash
+# 使用方法
+/git:sync
+```
+
+### /git:pr
+Git差分を元にコミット、新しいブランチ作成、プッシュ、PR作成を自動化します。
+```bash
+# 使用方法
+/git:pr "PRタイトル"
+```
+
 ## 注意事項
 
 - Go 1.23を使用（go.modで指定）


### PR DESCRIPTION
## 概要
プロジェクトのドキュメントにグローバルカスタムコマンドの説明を追加しました。

## 変更内容

### 📚 ドキュメント更新
- **CLAUDE.md**: グローバルカスタムコマンドセクションを追加
  - /git:sync と /git:pr コマンドの使用方法を記載
  - コマンドがグローバル定義（~/.claude/commands）であることを明記

- **.cursor/rules/global.md**: Gitコマンドの詳細説明を追加
  - 利用可能なGitコマンド一覧（/git:sync, /git:pr, /git:push-head, /git:rebase）
  - グローバル定義の場所を明記

### 🔧 構成変更
- git-sync.mdをプロジェクトローカルからグローバルディレクトリへ移動
  - 移動先: ~/.claude/commands/git-sync.md
  - すべてのプロジェクトで利用可能に

## 影響範囲
- ドキュメントのみの変更
- 既存コードへの影響なし